### PR TITLE
add mapping, address and location entities to stack

### DIFF
--- a/config/authorization/config.lisp
+++ b/config/authorization/config.lisp
@@ -29,16 +29,33 @@
 
 (type-cache::add-type-for-prefix "http://mu.semte.ch/sessions/" "http://mu.semte.ch/vocabularies/session/Session")
 
+;; Prefixes used in the constraints below (not in the SPARQL queries)
+(define-prefixes
+  :mu "http://mu.semte.ch/vocabularies/core/"
+  :session "http://mu.semte.ch/vocabularies/session/"
+  :ext "http://mu.semte.ch/vocabularies/ext/"
+  :sssom "https://w3id.org/sssom/"
+  :locn "http://www.w3.org/ns/locn#"
+  :dct "http://purl.org/dc/terms/"
+  )
+
 (define-graph ticketgang-locaties ("http://locatieslinkeddata.ticketgang-locations.ticketing.acagroup.be")
-  (_ -> _))
+  ("locn:Address" -> _)
+  ("dct:Location" -> _))
 (define-graph kunstenpunt-locaties ("http://locatiessparql.kunstenpunt-locaties.professionelekunsten.kunsten.be")
-  (_ -> _))
+  ("locn:Address" -> _)
+  ("dct:Location" -> _))
 (define-graph cultuurparticipatie-metadata ("http://metadata.cultuurparticipatie-metadata.vrijetijdsparticipatie.publiq.be")
-  (_ -> _))
+  ("locn:Address" -> _)
+  ("dct:Location" -> _))
 (define-graph publiq-uit-locaties ("http://placessparql.publiq-uit-locaties.vrijetijdsparticipatie.publiq.be")
-  (_ -> _))
+  ("locn:Address" -> _)
+  ("dct:Location" -> _))
 (define-graph publiq-uit-organisatoren ("http://organisatorensparql.publiq-uit-organisatoren.vrijetijdsparticipatie.publiq.be")
-  (_ -> _))  
+  ("locn:Address" -> _)
+  ("dct:Location" -> _))
+(define-graph mappings ("http://mu.semte.ch/graphs/entity-mappings")
+  ("sssom:Mapping" -> _))
 
 (supply-allowed-group "public")
 
@@ -50,9 +67,13 @@
       } LIMIT 1")
 
 (grant (read)
-  :to-graph (ticketgang-locaties
+  :to-graph (ticketgang-locaties 
              kunstenpunt-locaties
              cultuurparticipatie-metadata 
              publiq-uit-locaties 
              publiq-uit-organisatoren)
+  :for-allowed-group "logged-in")
+
+(grant (read)
+  :to-graph (mappings)
   :for-allowed-group "logged-in")

--- a/config/authorization/config.lisp
+++ b/config/authorization/config.lisp
@@ -29,16 +29,33 @@
 
 (type-cache::add-type-for-prefix "http://mu.semte.ch/sessions/" "http://mu.semte.ch/vocabularies/session/Session")
 
+;; Prefixes used in the constraints below (not in the SPARQL queries)
+(define-prefixes
+  :mu "http://mu.semte.ch/vocabularies/core/"
+  :session "http://mu.semte.ch/vocabularies/session/"
+  :ext "http://mu.semte.ch/vocabularies/ext/"
+  :sssom "https://w3id.org/sssom/"
+  :locn "http://www.w3.org/ns/locn#"
+  :dct "http://purl.org/dc/terms/"
+  )
+
 (define-graph ticketgang-locaties ("http://locatieslinkeddata.ticketgang-locations.ticketing.acagroup.be")
-  (_ -> _))
+  ("locn:Address" -> _)
+  ("dct:Location" -> _))
 (define-graph kunstenpunt-locaties ("http://locatiessparql.kunstenpunt-locaties.professionelekunsten.kunsten.be")
-  (_ -> _))
+  ("locn:Address" -> _)
+  ("dct:Location" -> _))
 (define-graph cultuurparticipatie-metadata ("http://metadata.cultuurparticipatie-metadata.vrijetijdsparticipatie.publiq.be")
-  (_ -> _))
+  ("locn:Address" -> _)
+  ("dct:Location" -> _))
 (define-graph publiq-uit-locaties ("http://placessparql.publiq-uit-locaties.vrijetijdsparticipatie.publiq.be")
-  (_ -> _))
+  ("locn:Address" -> _)
+  ("dct:Location" -> _))
 (define-graph publiq-uit-organisatoren ("http://organisatorensparql.publiq-uit-organisatoren.vrijetijdsparticipatie.publiq.be")
-  (_ -> _))  
+  ("locn:Address" -> _)
+  ("dct:Location" -> _))
+(define-graph mappings ("http://mu.semte.ch/graphs/entity-mappings")
+  ("sssom:Mapping" -> _))
 
 (supply-allowed-group "public")
 
@@ -49,10 +66,14 @@
           <SESSION_ID> session:account ?account .
       } LIMIT 1")
 
-(grant (read write)
+(grant (read)
   :to-graph (ticketgang-locaties 
              kunstenpunt-locaties
              cultuurparticipatie-metadata 
              publiq-uit-locaties 
              publiq-uit-organisatoren)
+  :for-allowed-group "logged-in")
+
+(grant (read)
+  :to-graph (mappings)
   :for-allowed-group "logged-in")

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -34,15 +34,15 @@ defmodule Dispatcher do
   #################
 
   match "/mappings/*path", %{ layer: :services, accept: %{ json: true } } do
-    forward conn, path, "http://cache/accounts/"
+    Proxy.forward conn, path, "http://cache/accounts/"
   end
 
   match "/addresses/*path", %{ layer: :services, accept: %{ json: true } } do
-    forward conn, path, "http://cache/addresses/"
+    Proxy.forward conn, path, "http://cache/addresses/"
   end
 
   match "/locations/*path", %{ layer: :services, accept: %{ json: true } } do
-    forward conn, path, "http://cache/locations/"
+    Proxy.forward conn, path, "http://cache/locations/"
   end
 
   match "/sessions/*path", @any do

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -29,6 +29,22 @@ defmodule Dispatcher do
     Proxy.forward conn, [], "http://frontend/index.html"
   end
 
+  #################
+  # SERVICES
+  #################
+
+  match "/mappings/*path", %{ layer: :services, accept: %{ json: true } } do
+    forward conn, path, "http://cache/accounts/"
+  end
+
+  match "/addresses/*path", %{ layer: :services, accept: %{ json: true } } do
+    forward conn, path, "http://cache/addresses/"
+  end
+
+  match "/locations/*path", %{ layer: :services, accept: %{ json: true } } do
+    forward conn, path, "http://cache/locations/"
+  end
+
   match "/sessions/*path", @any do
     Proxy.forward conn, path, "http://login/sessions/"
   end

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -140,10 +140,6 @@
           "type": "string",
           "predicate": "locn:locatorName"
         },
-        "geometry": {
-          "type": "url",
-          "predicate": "locn:geometry"
-        },
         "invalidated": {
           "type": "date",
           "predicate": "prov:invalidatedAtTime"
@@ -162,12 +158,39 @@
           "predicate": "locn:address",
           "target": "address",
           "cardinality": "one"
+        },
+        "geometry": {
+          "predicate": "locn:geometry",
+          "target": "geometry",
+          "cardinality": "one"
         }
       },
       "features": [
         "include-uri"
       ],
       "new-resource-base": "http://data.publiq.be/locations/"
+    },
+    "geometries": {
+      "name": "geometry",
+      "class": "locn:Geometry",
+      "attributes": {
+        "gml": {
+          "type": "string",
+          "predicate": "geo:asGML"
+        }
+      },
+      "relationships": {
+        "location": {
+          "predicate": "locn:geometry",
+          "target": "location",
+          "cardinality": "one",
+          "inverse": true
+        }
+      },
+      "features": [
+        "include-uri"
+      ],
+      "new-resource-base": "http://data.publiq.be/geometries/"
     }
   }
 }

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -46,6 +46,10 @@
         "object": {
           "type": "url",
           "predicate": "sssom:object_id"
+        },
+        "predicate": {
+          "type": "url",
+          "predicate": "sssom:predicate_id"
         }
       },
       "relationships": {},

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -39,11 +39,11 @@
           "type": "float",
           "predicate": "sssom:similarity_score"
         },
-        "subject-uri": {
+        "subject": {
           "type": "url",
           "predicate": "sssom:subject_id"
         },
-        "object-uri": {
+        "object": {
           "type": "url",
           "predicate": "sssom:object_id"
         }
@@ -66,7 +66,7 @@
           "type": "date",
           "predicate": "dct:modified"
         },
-        "full-address": {
+        "address": {
           "type": "language-string",
           "predicate": "locn:fullAddress"
         },
@@ -74,19 +74,19 @@
           "type": "string",
           "predicate": "locn:postCode"
         },
-        "postname": {
+        "city": {
           "type": "language-string",
           "predicate": "locn:postName"
         },
-        "thoroughfare": {
+        "street": {
           "type": "language-string",
           "predicate": "locn:thoroughfare"
         },
-        "locator-designator": {
+        "number": {
           "type": "string",
           "predicate": "locn:locatorDesignator"
         },
-        "adminunit-l1": {
+        "country": {
           "type": "string",
           "predicate": "locn:adminUnitL1"
         },
@@ -132,7 +132,7 @@
           "type": "url",
           "predicate": "adms:identifier"
         },
-        "locator-name": {
+        "name": {
           "type": "string",
           "predicate": "locn:locatorName"
         },

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -1,0 +1,169 @@
+{
+  "version": "0.1",
+  "prefixes": {
+    "prov": "http://www.w3.org/ns/prov#",
+    "locn": "http://www.w3.org/ns/locn#",
+    "sssom": "https://w3id.org/sssom/",
+    "dct": "http://purl.org/dc/terms/",
+    "ext": "http://mu.semte.ch/vocabularies/ext/",
+    "uitplatform": "https://data.uitwisselingsplatform.be/ns/platform#",
+    "adms": "http://www.w3.org/ns/adms#",
+    "uitdatabank": "https://data.publiq.be/ns/uitdatabank#"
+  },
+  "resources": {
+    "mappings": {
+      "name": "mapping",
+      "class": "sssom:Mapping",
+      "attributes": {
+        "created": {
+          "type": "date",
+          "predicate": "dct:created"
+        },
+        "modified": {
+          "type": "date",
+          "predicate": "dct:modified"
+        },
+        "justification": {
+          "type": "url",
+          "predicate": "sssom:mapping_justification"
+        },
+        "subject-label": {
+          "type": "string",
+          "predicate": "sssom:subject_label"
+        },
+        "object-label": {
+          "type": "string",
+          "predicate": "sssom:object_label"
+        },
+        "score": {
+          "type": "float",
+          "predicate": "sssom:similarity_score"
+        },
+        "subject-uri": {
+          "type": "url",
+          "predicate": "sssom:subject_id"
+        },
+        "object-uri": {
+          "type": "url",
+          "predicate": "sssom:object_id"
+        }
+      },
+      "relationships": {},
+      "features": [
+        "include-uri"
+      ],
+      "new-resource-base": "http://data.publiq.be/mappings/"
+    },
+    "addresses": {
+      "name": "address",
+      "class": "locn:Address",
+      "attributes": {
+        "created": {
+          "type": "date",
+          "predicate": "dct:created"
+        },
+        "modified": {
+          "type": "date",
+          "predicate": "dct:modified"
+        },
+        "full-address": {
+          "type": "language-string",
+          "predicate": "locn:fullAddress"
+        },
+        "postcode": {
+          "type": "string",
+          "predicate": "locn:postCode"
+        },
+        "postname": {
+          "type": "language-string",
+          "predicate": "locn:postName"
+        },
+        "thoroughfare": {
+          "type": "language-string",
+          "predicate": "locn:thoroughfare"
+        },
+        "locator-designator": {
+          "type": "string",
+          "predicate": "locn:locatorDesignator"
+        },
+        "adminunit-l1": {
+          "type": "string",
+          "predicate": "locn:adminUnitL1"
+        },
+        "po-box": {
+          "type": "string",
+          "predicate": "locn:poBox"
+        }
+      },
+      "relationships": {
+        "location": {
+          "predicate": "locn:address",
+          "target": "location",
+          "cardinality": "one",
+          "inverse": true
+        }
+      },
+      "features": [
+        "include-uri"
+      ],
+      "new-resource-base": "http://data.publiq.be/addresses/"
+    },
+    "locations": {
+      "name": "location",
+      "class": "dct:Location",
+      "attributes": {
+        "created": {
+          "type": "date",
+          "predicate": "dct:created"
+        },
+        "modified": {
+          "type": "date",
+          "predicate": "dct:modified"
+        },
+        "label": {
+          "type": "url",
+          "predicate": "rdfs:label"
+        },
+        "processed": {
+          "type": "date",
+          "predicate": "uitplatform:verwerktOp"
+        },
+        "identifier": {
+          "type": "url",
+          "predicate": "adms:identifier"
+        },
+        "locator-name": {
+          "type": "string",
+          "predicate": "locn:locatorName"
+        },
+        "geometry": {
+          "type": "url",
+          "predicate": "locn:geometry"
+        },
+        "invalidated": {
+          "type": "date",
+          "predicate": "prov:invalidatedAtTime"
+        },
+        "available-from": {
+          "type": "date",
+          "predicate": "uitdatabank:availableFrom"
+        },
+        "workflow-status": {
+          "type": "url",
+          "predicate": "uitdatabank:workflowStatus"
+        }
+      },
+      "relationships": {
+        "address": {
+          "predicate": "locn:address",
+          "target": "address",
+          "cardinality": "one"
+        }
+      },
+      "features": [
+        "include-uri"
+      ],
+      "new-resource-base": "http://data.publiq.be/locations/"
+    }
+  }
+}

--- a/config/resources/domain.lisp
+++ b/config/resources/domain.lisp
@@ -1,0 +1,11 @@
+(in-package :mu-cl-resources)
+
+(setf *include-count-in-paginated-responses* t)
+(setf *supply-cache-headers-p* t)
+(setf sparql:*experimental-no-application-graph-for-sudo-select-queries* t)
+(setf *cache-model-properties-p* t)
+(setf mu-support::*use-custom-boolean-type-p* nil)
+(setq *cache-count-queries-p* t)
+(setf sparql:*query-log-types* nil) ;; hint: use app-http-logger for logging queries instead, all is '(:default :update-group :update :query :ask)
+
+(read-domain-file "domain.json")

--- a/config/resources/repository.lisp
+++ b/config/resources/repository.lisp
@@ -1,0 +1,3 @@
+(in-package :mu-cl-resources)
+
+(add-prefix "ext" "http://mu.semte.ch/vocabularies/ext/")


### PR DESCRIPTION
configures resources, sparql-parser and dispatcher to be able to *read* these resources.

As they are imported or created in a service, only "read" access has been given.

Note that some "wrong" predicates are not mapped (e.g. `locn:fulladdress`). Is this desired (by giving it a name like "full-address2"), or is it okay to make the assumption for correct data when viewing it through resources?